### PR TITLE
Add exit on error threshold

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.6
     - php: 7.0
     - php: 7.1
+    - php: 7.2
+    - php: 7.3
     - php: nightly
   allow_failures:
     - php: nightly

--- a/bin/clover-coverage
+++ b/bin/clover-coverage
@@ -1,0 +1,3 @@
+#!/usr/bin/env php
+<?php
+require __DIR__ . '/clover-coverage.php';

--- a/bin/clover-coverage.php
+++ b/bin/clover-coverage.php
@@ -2,15 +2,17 @@
 <?php
 
 use Photogabble\CloverCoverage\CloverCoverageApplication;
+use Photogabble\CloverCoverage\Commands\Analyse;
 
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require __DIR__ . '/../vendor/autoload.php';
-} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
-    require __DIR__ . '/../../../autoload.php';
 } else {
-    throw new Exception('Unable to find an autoloader. Please run composer install.');
+    echo 'Cannot find the vendor directory, have you executed composer install?' . PHP_EOL;
+    echo 'See https://getcomposer.org to get Composer.' . PHP_EOL;
+    exit(1);
 }
 
 $app = new CloverCoverageApplication();
-$app->add(new \Photogabble\CloverCoverage\Commands\Analyse());
+$app->add(new Analyse());
+
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   ],
   "require": {
     "php": ">=5.6",
-    "symfony/console": "~2.8|3.*|4.*"
+    "symfony/console": "~2.8|3.*|4.*",
+    "ext-simplexml": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "5.*|6.*|7.*"

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -51,9 +51,26 @@ class Analyser
         }
 
         $this->filePathname = $filePathname;
-        $this->warningPercentage = $warningPercentage;
-        $this->errorPercentage = $errorPercentage;
-        $this->failurePercentage = $failurePercentage;
+        $this->warningPercentage = $this->normalisePercentage($warningPercentage);
+        $this->errorPercentage = $this->normalisePercentage($errorPercentage);
+        $this->failurePercentage = $this->normalisePercentage($failurePercentage);
+    }
+
+    /**
+     * Normalise the input percentage between 0 and 100.
+     *
+     * @param int $input
+     * @return int
+     */
+    private function normalisePercentage($input)
+    {
+        if ($input < 0) {
+            return 0;
+        } else if ($input > 100) {
+            return 100;
+        }
+
+        return $input;
     }
 
     /**

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -2,6 +2,8 @@
 
 namespace Photogabble\CloverCoverage;
 
+use Exception;
+use SimpleXMLElement;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -40,12 +42,12 @@ class Analyser
      * @param int $errorPercentage
      * @param int $failurePercentage
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function __construct($filePathname, $warningPercentage = 90, $errorPercentage = 80, $failurePercentage = 0)
     {
-        if (! file_exists($filePathname)){
-            throw new \Exception('No file could be read at path ['. $filePathname .']');
+        if (!file_exists($filePathname)) {
+            throw new Exception('No file could be read at path [' . $filePathname . ']');
         }
 
         $this->filePathname = $filePathname;
@@ -61,7 +63,7 @@ class Analyser
      */
     public function analyse()
     {
-        $cloverXml = new \SimpleXMLElement($this->filePathname, null, true);
+        $cloverXml = new SimpleXMLElement($this->filePathname, null, true);
         $analysis = new Analysis();
 
         foreach ($cloverXml->xpath('//file') as $file) {
@@ -108,9 +110,9 @@ class Analyser
         $table = new Table($output);
         $table->setStyle('borderless');
         $table->setHeaders(['File', 'Coverage']);
-        foreach($this->analysis->files as $name => $file) {
+        foreach ($this->analysis->files as $name => $file) {
             $percentage = $file->getCoveragePercentage();
-            if ($percentage < $this->errorPercentage){
+            if ($percentage < $this->errorPercentage) {
                 $icon = '!';
             } elseif ($percentage < $this->warningPercentage) {
                 $icon = '-';

--- a/src/CloverCoverageApplication.php
+++ b/src/CloverCoverageApplication.php
@@ -2,9 +2,11 @@
 
 namespace Photogabble\CloverCoverage;
 
-class CloverCoverageApplication extends \Symfony\Component\Console\Application
+use Symfony\Component\Console\Application;
+
+class CloverCoverageApplication extends Application
 {
-    public function __construct($name = 'Clover Coverage Cli', $version = '1.0.0')
+    public function __construct($name = 'Clover Coverage Cli', $version = '1.1.0')
     {
         parent::__construct($name, $version);
     }

--- a/src/Commands/Analyse.php
+++ b/src/Commands/Analyse.php
@@ -18,10 +18,13 @@ class Analyse extends Command
     public function configure()
     {
         $this->setName('analyse')
-            ->setDescription('Analyses clover.xml and outputs coverage information broken down by file');
-
-        $this->addArgument('clover-file', InputArgument::REQUIRED, 'Path to valid clover.xml file');
-        $this->addOption('summary', 's', InputOption::VALUE_NONE, 'Only show total coverage');
+            ->setDescription('Analyses clover.xml and outputs coverage information broken down by file')
+            ->addArgument('clover-file', InputArgument::REQUIRED, 'Path to valid clover.xml file')
+            ->addOption('failure-percentage', 'f', InputOption::VALUE_OPTIONAL, 'Threshold below which files are marked as failed', 0)
+            ->addOption('warning-percentage', 'w', InputOption::VALUE_OPTIONAL, 'Threshold below which files are marked as warning', 90)
+            ->addOption('error-percentage', 'e', InputOption::VALUE_OPTIONAL, 'Threshold below which files are marked as error', 80)
+            ->addOption('exit', null, InputOption::VALUE_OPTIONAL, 'Exit with error if overall coverage is equal to or less than failure percentage.')
+            ->addOption('summary', 's', InputOption::VALUE_NONE, 'Only show total coverage');
     }
 
     /**
@@ -32,7 +35,13 @@ class Analyse extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            $analyser = new Analyser($input->getArgument('clover-file'));
+            $analyser = new Analyser(
+                $input->getArgument('clover-file'),
+                $input->getOption('warning-percentage'),
+                $input->getOption('error-percentage'),
+                $input->getOption('failure-percentage')
+            );
+
             $analyser->analyse();
 
             if (count($analyser->getAnalysis()->files) < 1) {
@@ -45,7 +54,15 @@ class Analyse extends Command
                 $table->render();
             }
 
-            $output->writeln('Code Coverage: ' . number_format($analyser->getCoveragePercentage(), 2) . '%');
+            $percentage = $analyser->getCoveragePercentage();
+            $output->writeln('Code Coverage: ' . number_format($percentage, 2) . '%');
+
+            if ($exit = $input->getOption('exit')) {
+                if ($percentage <= $exit) {
+                    return 1;
+                }
+            }
+
         } catch (Exception $e) {
             $output->writeln('<error>[!]</error> ' . $e->getMessage());
             return 2;

--- a/src/Commands/Analyse.php
+++ b/src/Commands/Analyse.php
@@ -2,6 +2,7 @@
 
 namespace Photogabble\CloverCoverage\Commands;
 
+use Exception;
 use Photogabble\CloverCoverage\Analyser;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -39,13 +40,13 @@ class Analyse extends Command
                 return 1;
             }
 
-            if ($input->getOption('summary') === false ){
+            if ($input->getOption('summary') === false) {
                 $table = $analyser->getTable($output);
                 $table->render();
             }
 
             $output->writeln('Code Coverage: ' . number_format($analyser->getCoveragePercentage(), 2) . '%');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $output->writeln('<error>[!]</error> ' . $e->getMessage());
             return 2;
         }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -3,6 +3,7 @@
 namespace Photogabble\CloverCoverage\Tests;
 
 use Photogabble\CloverCoverage\CloverCoverageApplication;
+use Photogabble\CloverCoverage\Commands\Analyse;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
@@ -11,7 +12,7 @@ class ApplicationTest extends TestCase
     public function testApplication()
     {
         $app = new CloverCoverageApplication();
-        $app->add(new \Photogabble\CloverCoverage\Commands\Analyse());
+        $app->add(new Analyse());
         $app->setAutoExit(false);
         $applicationTester = new ApplicationTester($app);
 
@@ -19,12 +20,12 @@ class ApplicationTest extends TestCase
         $this->assertEquals(1, $applicationTester->run(['command' => 'analyse']));
 
         // Expect Error with invalid xml file location
-        $this->assertEquals(2, $applicationTester->run(['command' => 'analyse', 'clover-file'=> 'not-exist.xml']));
+        $this->assertEquals(2, $applicationTester->run(['command' => 'analyse', 'clover-file' => 'not-exist.xml']));
 
-        // Expect
-        $this->assertEquals(1, $applicationTester->run(['command' => 'analyse', 'clover-file'=> realpath(__DIR__ . DIRECTORY_SEPARATOR . 'broken.xml')]));
+        // Expect Error with invalid xml file
+        $this->assertEquals(1, $applicationTester->run(['command' => 'analyse', 'clover-file' => realpath(__DIR__ . DIRECTORY_SEPARATOR . 'broken.xml')]));
 
         // Expect No Error with valid xml file location
-        $this->assertEquals(0, $applicationTester->run(['command' => 'analyse', 'clover-file'=> realpath(__DIR__ . DIRECTORY_SEPARATOR . 'clover.xml')]));
+        $this->assertEquals(0, $applicationTester->run(['command' => 'analyse', 'clover-file' => realpath(__DIR__ . DIRECTORY_SEPARATOR . 'clover.xml')]));
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -23,9 +23,17 @@ class ApplicationTest extends TestCase
         $this->assertEquals(2, $applicationTester->run(['command' => 'analyse', 'clover-file' => 'not-exist.xml']));
 
         // Expect Error with invalid xml file
-        $this->assertEquals(1, $applicationTester->run(['command' => 'analyse', 'clover-file' => realpath(__DIR__ . DIRECTORY_SEPARATOR . 'broken.xml')]));
+        $this->assertEquals(1, $applicationTester->run(['command' => 'analyse', 'clover-file' => $this->realpath('broken.xml')]));
 
         // Expect No Error with valid xml file location
-        $this->assertEquals(0, $applicationTester->run(['command' => 'analyse', 'clover-file' => realpath(__DIR__ . DIRECTORY_SEPARATOR . 'clover.xml')]));
+        $this->assertEquals(0, $applicationTester->run(['command' => 'analyse', 'clover-file' => $this->realpath('clover.xml')]));
+
+        // Expect Error with valid xml file that has coverage below --exit
+        $this->assertEquals(1, $applicationTester->run(['command' => 'analyse', 'clover-file' => $this->realpath('clover.xml'), '--exit' => 90]));
+    }
+
+    private function realpath($string)
+    {
+        return realpath(__DIR__ . DIRECTORY_SEPARATOR . $string);
     }
 }


### PR DESCRIPTION
In order for this tool to be useful within CI pipeline it needed to be able to exit with error code if the input source has a coverage equal to or less than what is defined.